### PR TITLE
fix: Forgot ^ in Composer and Namespace Errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,17 +18,16 @@
   ],
   "require": {
     "php": ">=7.2",
-    "illuminate/support": "5.8",
-    "illuminate/queue": "5.8",
-    "illuminate/bus": "5.8"
+    "illuminate/support": "^5.8",
+    "illuminate/queue": "^5.8",
+    "illuminate/bus": "^5.8"
   },
   "require-dev": {
-    "phpunit/phpunit": "6.*",
-    "codeclimate/php-test-reporter": "dev-master"
+    "phpunit/phpunit": "^8.2.1"
   },
   "autoload": {
     "psr-4": {
-      "Myli\\PlainSqs\\": "src/"
+      "Myli\\PlainJobs\\": "src/"
     }
   }
 }

--- a/tests/PlainSqs/QueueTest.php
+++ b/tests/PlainSqs/QueueTest.php
@@ -1,14 +1,14 @@
 <?php
 
-namespace Myli\PlainSqs\Tests;
+namespace Myli\PlainJobs\Tests;
 
 use \PHPUnit\Framework\TestCase;
-use Myli\PlainSqs\Jobs\DispatcherJob;
-use Myli\PlainSqs\Sqs\Queue;
+use Myli\PlainJobs\Jobs\DispatcherJob;
+use Myli\PlainJobs\Sqs\Queue;
 
 /**
  * Class QueueTest
- * @package Myli\PlainSqs\Tests
+ * @package Myli\PlainJobs\Tests
  */
 class QueueTest extends TestCase
 {


### PR DESCRIPTION
Look for everything about version 5.8 in illuminate not specific 5.8