### PR TITLE
feat: Add Also Attributes in Data to Job

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "ext-json": "*"
   },
   "require-dev": {
-    "phpspec/phpspec": "^5.1"
+    "phpspec/phpspec": "^5.1|^6.1"
   },
   "autoload": {
     "psr-4": {

--- a/src/PubSub/Job.php
+++ b/src/PubSub/Job.php
@@ -71,10 +71,13 @@ class Job extends IlluminateJob implements JobContract
      */
     public function getRawBody()
     {
-        $data     = json_decode(base64_decode($this->job->data()), true);
+        $fullData = [
+            'data' => json_decode(base64_decode($this->job->data()), true),
+            'attributes' => $this->job->attributes()
+        ];
         $newArray = [
             'job'  => $this->classHandler . '@handle',
-            'data' => $data,
+            'data' => $fullData,
         ];
 
         return json_encode($newArray);


### PR DESCRIPTION
Example : When subscribing a notification to GCS on PubSub, GCS only send attributes back to the job, so our data is null.